### PR TITLE
Force install of VmwareTools

### DIFF
--- a/scripts/vmware.sh
+++ b/scripts/vmware.sh
@@ -6,7 +6,7 @@ cd /tmp
 mkdir -p /mnt/cdrom
 mount -o loop ~/linux.iso /mnt/cdrom
 tar zxf /mnt/cdrom/VMwareTools-*.tar.gz -C /tmp/
-/tmp/vmware-tools-distrib/vmware-install.pl -d
+/tmp/vmware-tools-distrib/vmware-install.pl -d --force-install
 rm /home/vagrant/linux.iso
 umount /mnt/cdrom
 


### PR DESCRIPTION
`--force-install` is required, otherwise will suggest go for open-vm-tools.

This change has been tested, and proven that works.